### PR TITLE
Match right side padding when ToC is used on left

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -305,7 +305,7 @@ h6:hover .anchor {
         z-index: 1;
     }
     .toc.side.left {
-        left: 0px;
+        left: 15px;
         width: 250px;
     }
     .toc.side.right {


### PR DESCRIPTION
Simply bumps padding on left ToC to 15px to match that of right ToC -- the hard-alignment with no padding is a bit jarring ATM.