### PR TITLE
Add "[Pinned]" text after title when a post is pinned using `weight`

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -61,7 +61,8 @@
   <header class="entry-header">
     <h2>
       {{- .Title }}
-      {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
+      {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[Draft]</span></sup>{{- end }}
+      {{- if .Weight }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[Pinned]</span></sup>{{- end }}
     </h2>
   </header>
   {{- if (ne (.Param "hideSummary") true) }}


### PR DESCRIPTION
Also updates "draft" to "Draft" to properly capitalize the word (IMO).