### PR TITLE
New Features : Add Giscus comments support

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -24,4 +24,10 @@
     {{- partial "disqus.html" (dict "page" $page "ctx" .) }}
   {{- end -}}
   {{- end -}}
+
+  {{- if $pageCommentSystems.giscus -}}
+  {{- with .giscus -}}
+    {{- partial "giscus.html" (dict "page" $page "ctx" .) }}
+  {{- end -}}
+  {{- end -}}
 {{- end -}}

--- a/layouts/partials/giscus.html
+++ b/layouts/partials/giscus.html
@@ -1,0 +1,82 @@
+<div class="comments">
+  <div id="giscus"></div>
+</div>
+
+<script type="text/javascript">
+  // Update giscus frame
+  function sendMessage(message) {
+    const iframe = document.querySelector('iframe.giscus-frame');
+    if (!iframe) return;
+    iframe.contentWindow.postMessage({ giscus: message }, 'https://giscus.app');
+  }
+
+  // Config
+  var setConfig = {
+    "src": "{{ .ctx.src }}" || "https://giscus.app/client.js",
+    "repo": "{{ .ctx.data_repo }}",
+    "repoId": "{{ .ctx.data_repo_id }}",
+    "category": "{{ .ctx.data_category }}" || "Announcements",
+    "categoryId": "{{ .ctx.data_category_id }}",
+    "data-mapping": "{{ .ctx.data_mapping }}" || "pathname",
+    "reactionsEnabled": "{{ .ctx.data_reactions_enabled }}" || "1",
+    "emitMetadata": "{{ .ctx.data_emit_metadata }}" || "0",
+    "inputPosition": "{{ .ctx.data_input_position }}" || "bottom",
+    "theme": localStorage.getItem("pref-theme") || "{{ .ctx.data_theme }}" || "preferred_color_scheme",
+    "lang": "{{ .ctx.data_lang }}" || "en",
+    "crossorigin": "{{ .ctx.crossorigin }}" || "anonymous"
+  };
+
+  // Page load config
+  if (isDarkTheme()) {
+    setConfig["theme"] = 'dark'
+  }
+
+
+  // Load function
+  (function () {
+    // toogle theme callback
+    const key = 'giscus'
+    if (!toggleThemeCallbacks.hasOwnProperty(key)) {
+      toggleThemeCallbacks[key] = (isDark) => {
+        // const giscus = window.GISCUS
+        // if (!giscus || !document.querySelector('#giscus')) {
+        //   return;
+        // }
+        if (isDark) {
+          setConfig["theme"] = 'light'
+          sendMessage({ setConfig });
+          // giscus.changeTheme('light');
+        } else {
+          setConfig["theme"] = 'dark'
+          sendMessage({ setConfig });
+          // giscus.changeTheme('dark');
+        }
+      }
+    }
+
+    const giscus = document.querySelector('iframe.giscus-frame')
+    if (giscus) {
+      sendMessage({ setConfig });
+    } else {
+      var giscus_script = document.createElement('script');
+      giscus_script.defer = true
+      giscus_script.setAttribute("src", setConfig["src"]);
+      giscus_script.setAttribute("data-repo", setConfig["repo"]);
+      giscus_script.setAttribute("data-repo-id", setConfig["repoId"]);
+      giscus_script.setAttribute("data-category", setConfig["category"]);
+      giscus_script.setAttribute("data-category-id", setConfig["categoryId"]);
+      giscus_script.setAttribute("data-mapping", setConfig["data-mapping"]);
+      giscus_script.setAttribute("data-strict", setConfig.data_strict);
+      giscus_script.setAttribute("data-reactions-enabled", setConfig["reactionsEnabled"]);
+      giscus_script.setAttribute("data-emit-metadata", setConfig["emitMetadata"]);
+      giscus_script.setAttribute("data-input-position", setConfig["inputPosition"]);
+      giscus_script.setAttribute("data-theme", setConfig["theme"]);
+      giscus_script.setAttribute("data-lang", setConfig["lang"]);
+      giscus_script.setAttribute("data-loading", "lazy");
+      giscus_script.setAttribute("crossorigin", setConfig["crossorigin"]);
+      document.getElementById("giscus").appendChild(giscus_script);
+    }
+  })();
+
+
+</script>

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -2,7 +2,7 @@
 {{- if not .Date.IsZero -}}
 <span class="meta-item">
   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-calendar" style="user-select: text;"><rect x="3" y="4" width="18" height="18" rx="2" ry="2" style="user-select: text;"></rect><line x1="16" y1="2" x2="16" y2="6" style="user-select: text;"></line><line x1="8" y1="2" x2="8" y2="6" style="user-select: text;"></line><line x1="3" y1="10" x2="21" y2="10" style="user-select: text;"></line></svg>
-  <span>{{ .Date | time.Format (default "January 2, 2006" site.Params.DateFormat) }}</span></span>
+  <span>&nbsp;{{ .Date | time.Format (default "January 2, 2006" site.Params.DateFormat) }}</span></span>
 {{- end }}
 
 {{- if .Params.tags -}}


### PR DESCRIPTION
Add `giscus.html` partial with color theme sync.

Config example: 
```yaml
commentSystems:
        giscus:
            data_repo: [DATA_REPO]
            data_repo_id: [DATA_REPO_ID]
            data_category_id: [DATA_CATEGORY]
            data_mapping
            data_reactions_enabled
            data_emit_metadata
            data_input_position
            data_lang
            crossorigin
    defaultCommentSystems:
        giscus: true
```