### PR TITLE
feat: footer custom text

### DIFF
--- a/exampleSite/config.default.yml
+++ b/exampleSite/config.default.yml
@@ -116,6 +116,9 @@ params:
   #     threshold: 0.4
   #     minMatchCharLength: 0
   #     keys: ["title", "permalink", "summary", "content"]
+  
+  footer:
+    customText:
 
 minify:
   disableXML: true

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,6 +13,9 @@
     <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">Hugo</a> &
     <a href="https://github.com/reorx/hugo-PaperModX/" rel="noopener" target="_blank">PaperModX</a>
   </span>
+  {{ with .Site.Params.footer.customText }}
+    <div>{{ . | safeHTML }}</div>
+  {{ end }}
 </footer>
 {{- end }}
 


### PR DESCRIPTION
I needed to place custom text at the bottom of the site, so I added this feature.

Reference: https://github.com/CaiJimmy/hugo-theme-stack/pull/74

Use case:
```toml
# config.toml
[params.footer]
customText = '<a href="https://beian.miit.gov.cn/" target="_blank">浙ICP备17043186号-1</a>'
```
<img width="430" alt="备案信息" src="https://user-images.githubusercontent.com/18254135/195019620-d13dfa51-9c07-4404-8052-d86b54bbba45.png">
