### PR TITLE
Remove lazy loading in cover

### DIFF
--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -15,7 +15,7 @@
         {{- end -}}
         {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) }}
         {{- if (and (in $processableFormats $cover.MediaType.SubType) ($responsiveImages) (eq $prod true)) }}
-        <img loading="lazy" srcset="{{- range $size := $sizes -}}
+        <img srcset="{{- range $size := $sizes -}}
                         {{- if (ge $cover.Width $size) -}}
                         {{ printf "%s %s" (($cover.Resize (printf "%sx" $size)).Permalink) (printf "%sw ," $size) -}}
                         {{ end }}


### PR DESCRIPTION
Lazy loading an image in the LCP raises a diagnostic error in Google Lighthouse

https://web.dev/lcp-lazy-loading/