### PR TITLE
Update go.mod for PaperModX

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/adityatelange/hugo-PaperMod
+module github.com/reorx/hugo-PaperModX
 
 go 1.12


### PR DESCRIPTION
The `go.mod` file is used when importing a theme as a module. This PR simply updates `go.mod` so that it points to the PaperModX repo instead of the PaperMod repo.