### PR TITLE
Menu visibility in dark mode

### DIFF
--- a/assets/css/core/theme-vars.css
+++ b/assets/css/core/theme-vars.css
@@ -29,7 +29,7 @@
     --line-yellow: url("data:image/svg+xml;charset=utf-8,%3Csvg preserveAspectRatio='none' width='120' height='6' viewBox='0 0 120 6' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M119 0.8C60 4 50-0.5 1 1.5' stroke='%23fc0' stroke-width='3' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
 
     /* for type pages theming */
-    --signature: var(--primary);
+    --signature: var(--secondary);
     --signature-bg: var(--secondary);
 }
 @media screen and (max-width: 500px) {


### PR DESCRIPTION
In dark mode, when a menu is clicked, and becomes active, it disappears, and is no longer visible. 
This commit solves it, and the menu's visibility persists even when it is active.