### PR TITLE
Make disableThemeToggle to actually disable theme functionality

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -26,14 +26,9 @@
 
 {{- partial "extend_footer.html" . }}
 
+{{ if not site.Params.disableThemeToggle -}}
 <script>
   (function() {
-    /* theme toggle */
-    const disableThemeToggle = '{{ if site.Params.disableThemeToggle }}1{{ end }}' == '1';
-    if (disableThemeToggle) {
-      return;
-    }
-
     let button = document.getElementById("theme-toggle")
     // remove the listeners first to prevent adding duplicated listener when history goes back and forth
     button.removeEventListener('click', toggleThemeListener)
@@ -41,6 +36,7 @@
     button.addEventListener('click', toggleThemeListener)
   })();
 </script>
+{{- end }}
 
 <script>
   (function () {

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,3 +1,4 @@
+{{ if not site.Params.disableThemeToggle -}}
 <script data-no-instant>
 function switchTheme(theme) {
   switch (theme) {
@@ -66,6 +67,7 @@ function toggleThemeListener() {
     switchTheme(theme);
   })();
 </script>
+{{- end }}
 
 <header class="header">
     <nav class="nav">


### PR DESCRIPTION
At this time, if you set disableThemeToggle=true, browser continues to load preferred theme from local storage and loads previously saved theme.