### PR TITLE
Deprecated: Remove reference to "resources.ToCSS"

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -42,12 +42,12 @@
 {{- $reset := (resources.Get "css/core/reset.css") }}
 {{- $media := (resources.Get "css/core/zmedia.css") }}
 {{- $common := (resources.Match "css/common/*.css") | resources.Concat "assets/css/common.css" }}
-{{- $commonHighlight := (resources.Get "css/common/highlight.scss") | resources.ToCSS }}
+{{- $commonHighlight := (resources.Get "css/common/highlight.scss") | css.Sass }}
 
 {{- /* order is important */}}
 {{- $core := (slice $theme_vars $reset $common $commonHighlight $media) | resources.Concat "assets/css/core.css" }}
 {{- $extended := (resources.Match "css/extended/*.css") | resources.Concat "assets/css/extended.css" }}
-{{- $extendedScss := (resources.Match "css/extended/*.scss") | resources.Concat "assets/css/extended.scss" | resources.ToCSS }}
+{{- $extendedScss := (resources.Match "css/extended/*.scss") | resources.Concat "assets/css/extended.scss" | css.Sass }}
 
 {{- /* bundle all required css */}}
 {{- /* Add extended css after theme style */ -}}


### PR DESCRIPTION
Error received while building site

> Start building sites …
> hugo v0.139.0+extended+withdeploy darwin/amd64 BuildDate=2024-11-18T16:17:45Z
> ...
> WARN  deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in a future release. Use css.Sass instead."
>