### PR TITLE
Update resources.ToCSS to toCSS due to deprecation

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -42,12 +42,12 @@
 {{- $reset := (resources.Get "css/core/reset.css") }}
 {{- $media := (resources.Get "css/core/zmedia.css") }}
 {{- $common := (resources.Match "css/common/*.css") | resources.Concat "assets/css/common.css" }}
-{{- $commonHighlight := (resources.Get "css/common/highlight.scss") | resources.ToCSS }}
+{{- $commonHighlight := (resources.Get "css/common/highlight.scss") | toCSS }}
 
 {{- /* order is important */}}
 {{- $core := (slice $theme_vars $reset $common $commonHighlight $media) | resources.Concat "assets/css/core.css" }}
 {{- $extended := (resources.Match "css/extended/*.css") | resources.Concat "assets/css/extended.css" }}
-{{- $extendedScss := (resources.Match "css/extended/*.scss") | resources.Concat "assets/css/extended.scss" | resources.ToCSS }}
+{{- $extendedScss := (resources.Match "css/extended/*.scss") | resources.Concat "assets/css/extended.scss" | toCSS }}
 
 {{- /* bundle all required css */}}
 {{- /* Add extended css after theme style */ -}}


### PR DESCRIPTION
See https://gohugo.io/functions/resources/tocss/ and https://gohugo.io/hugo-pipes/transpile-sass-to-css/.
Not completely sure if this is the best change